### PR TITLE
Fix logic for selecting when to use the v2 PuppetDB dashboards

### DIFF
--- a/manifests/dashboards/telegraf.pp
+++ b/manifests/dashboards/telegraf.pp
@@ -9,7 +9,7 @@ class puppet_metrics_dashboard::dashboards::telegraf {
     default => 'http',
   }
 
-  if (( 'localhost' in $puppet_metrics_dashboard::puppetdb_list ) and puppet_metrics_dashboard::puppetdb_no_remote_metrics() ) {
+  if puppet_metrics_dashboard::puppetdb_no_remote_metrics() {
     $pdb_dash_version = '_v2'
   } else {
     $pdb_dash_version = undef


### PR DESCRIPTION
The v2 PuppetDB dashboards should be used when PuppetDB is
run on a version of Puppet corresponding to a version of
PuppetDB with no remote access support.